### PR TITLE
[SCRUM-73] remove import order rule in ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,19 +25,6 @@
       "warn",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
-    "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
-    "import/order": [
-      "error",
-      {
-        "groups": ["builtin", "external", "internal", ["parent", "sibling", "index"]],
-        "pathGroups": [
-          { "pattern": "react", "group": "external", "position": "before" },
-          { "pattern": "@/**", "group": "internal" }
-        ],
-        "pathGroupsExcludedImportTypes": ["react"],
-        "alphabetize": { "order": "asc", "caseInsensitive": true },
-        "newlines-between": "always"
-      }
-    ]
+    "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }]
   }
 }


### PR DESCRIPTION
**[SCRUM-73]**
**Remove import order rule in ESLint configuration**
- Jira Ticket: [SCRUM-73](https://hellocitylandingai.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-73)

1. Changes- ✨ Remove import order rule in ESLint configuration
<img width="1630" height="1538" alt="image" src="https://github.com/user-attachments/assets/5fa03e74-171a-4aeb-a55b-fa813157bb95" />


