### PR TITLE
[86d02830n] update the commit message requirement

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -6,15 +6,15 @@ echo "Checking commit message format..."
 commit_msg_file=$1
 commit_msg=$(cat "$commit_msg_file")
 
-pattern='\[SCRUM-[0-9]+\] .+'
-
+pattern='^\[(SCRUM-[0-9]+|86d[a-z0-9]{6})\] .+'
 
 if ! echo "$commit_msg" | grep -Eq "$pattern"; then
   echo ""
-  echo "❌ Wrong format: commit message must include [SCRUM-<number>]."
+  echo "❌ Wrong format: commit message must start with either [SCRUM-<number>] or [86d<6 alphanumeric chars>]."
   echo ""
-  echo "✅ Correct format example:"
-  echo "   [SCRUM-123] your commit message"
+  echo "✅ Correct format examples:"
+  echo "   [SCRUM-123] Fix login bug"
+  echo "   [86d1a2b3c] Update readme"
   echo ""
   exit 1
 fi


### PR DESCRIPTION
Now, Husky allow the clickup ticket number to be the head of commit message

<img width="1327" height="208" alt="image" src="https://github.com/user-attachments/assets/82296648-bd17-4e8e-a630-cb6c63e92661" />
